### PR TITLE
Fix 404 error due to timezone issue, fix scroll bars disappearing, fix invalid date

### DIFF
--- a/src/backend/models/showing.model.js
+++ b/src/backend/models/showing.model.js
@@ -61,7 +61,7 @@ Showing.getByMovie = (movie_id, result) => {
             FROM  showing s 
                 INNER JOIN movie m ON m.movie_id = s.movie_id 
             WHERE m.movie_id = ${movie_id} 
-            AND CAST(start_date_time AS DATE)>= CAST(UTC_TIMESTAMP() AS DATE) 
+            AND CAST(date_sub(s.start_date_time, interval 6 hour) AS DATE)>= CAST(date_sub(UTC_TIMESTAMP(),interval 6 hour) AS DATE)  
             ORDER BY date ASC`, 
         (err, res) => {
         //Error encountered
@@ -143,16 +143,17 @@ Showing.getByDate = (date, result) => {
 
 // Get upcoming movies showing (movies not currently playing, but scheduled in the future)
 // UTC_TIMESTAMP() since we are storing in UTC 
+// Subtract 6 to get back to CST time
 Showing.getUpcoming = result => {
     sql.query(
             "SELECT DISTINCT  m.title, m.director, CAST(m.cast as CHAR) AS cast, CAST(m.plot as CHAR) AS plot, m.duration, m.rated, m.poster_URL, " +
                 "m.genre, DATE_FORMAT(m.release_date, '%c/%e/%Y'), s.showing_id, DATE_FORMAT(date_sub(start_date_time, interval 6 hour), '%c/%e/%Y %h:%i %p') AS start_date_time  " +
             "FROM  showing s " +
             "INNER JOIN movie m on m.movie_id = s.movie_id " +
-            "WHERE CAST(start_date_time AS DATE) >  UTC_TIMESTAMP() " + 
+            "WHERE CAST(date_sub(s.start_date_time, interval 6 hour) AS DATE) >  CAST(date_sub(UTC_TIMESTAMP(),interval 6 hour) AS DATE) " + 
             "AND s.movie_id NOT IN ( SELECT DISTINCT movie_id " +
                 "FROM showing " +
-                "WHERE CAST(start_date_time AS DATE) = CAST(UTC_TIMESTAMP() AS DATE)"+
+                "WHERE CAST(date_sub(s.start_date_time, interval 6 hour) AS DATE) = CAST(date_sub(UTC_TIMESTAMP(),interval 6 hour) AS DATE)"+
             ")", 
     (err, res) => {
         //Error encountered

--- a/src/frontend/pages/PurchaseTickets.js
+++ b/src/frontend/pages/PurchaseTickets.js
@@ -48,7 +48,7 @@ function PurchaseTickets(props) {
 	const [movieTimes, setMovieTimes] = useState([]);
 	const [movieTimesObj] = useState({});
 	const [numberOfViewers, setNumberOfViewers] = useState(1);
-	const [selectedDate, setSelectedDate] = useState(customerMovie.selected_date)
+	const [selectedDate, setSelectedDate] = useState("")
 	const [selectedShowingID, setselectedShowingID] = useState(null);
 	const [ticketType, setTicketType] = useState("theater")
 	const [timeError, setTimeError] = useState(false)
@@ -76,6 +76,7 @@ function PurchaseTickets(props) {
 
 		if (customerMovie.selected_date !== "") {
 			loadShowingTimes(customerMovie.selected_date);
+			setSelectedDate(customerMovie.selected_date)
 		}
 
 	}, [customerMovie])
@@ -103,7 +104,6 @@ function PurchaseTickets(props) {
 		setselectedShowingID(e.target.value)
 		setTimeError(false);
 	}
-
 	const handleDateChange = async (e) => {
 		setSelectedDate(e.target.value);
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,11 +32,12 @@ store.subscribe(()=>{
 //console.log("STORE ", store.getState())
 
 ReactDOM.render(
-  <React.StrictMode>
+  //Removing strict mode because AntD doesn't play nicely with it and loses scroll bars
+  //<React.StrictMode>
     <Provider store={store}>
       <App />
-    </Provider>
-  </React.StrictMode>,
+    </Provider>,
+  //</React.StrictMode>,
   document.getElementById('root')
 );
 


### PR DESCRIPTION
The invalid date issue was being caused by the date being set to the selected date on the showtime page or the current date when the component mounted, but sometimes the date was coming in as "" when it got set when another process was running to set that date in Redux.

I added a check to make sure the date is not an empty string before it is set which seems to be working.

The scroll bar issue was happening because AntD doesn't play well with React.StrictMode and was causing dom errors in the console.

The 404 error I encountered was occurring because I didn't subtract the 6 hours off the time in one query to get it in CST time, and this then caused issues if the showtimes for the current date were prior to 6:00 PM, but the current time was after 6:00 PM putting the UTC into tomorrow as a date.